### PR TITLE
Make hamburger menu background opaque on edge devices

### DIFF
--- a/frontend/src/components/AskCopilotModal.tsx
+++ b/frontend/src/components/AskCopilotModal.tsx
@@ -41,7 +41,7 @@ export function AskCopilotModal({
   }
 
   return (
-    <div className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-50 p-4">
+    <div className="fixed inset-0 bg-black md:bg-black/60 backdrop-blur-sm flex items-center justify-center z-50 p-4">
       <div className="bg-white rounded-2xl shadow-lg max-w-2xl w-full max-h-[90vh] overflow-hidden">
         {/* Header */}
         <div className="flex items-center justify-between p-6 border-b border-gray-100 bg-gradient-to-r from-primary-50 to-accent-50">


### PR DESCRIPTION
Make the modal overlay background opaque on mobile devices to improve visibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-3ad92741-b80c-4df2-9141-08342b7d6380"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3ad92741-b80c-4df2-9141-08342b7d6380"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

